### PR TITLE
Visually hide the signature cropping icon for now

### DIFF
--- a/client/src/components/signature-card.tsx
+++ b/client/src/components/signature-card.tsx
@@ -187,7 +187,7 @@ export function SignatureCard({
                 <Eye className="h-4 w-4" />
               </Button>
             )}
-            {signature.parameters && Object.keys(signature.parameters).length > 0 && (
+            {false && signature.parameters && Object.keys(signature.parameters).length > 0 && (
               <Button
                 variant="outline"
                 size="icon"


### PR DESCRIPTION
Temporarily hide the gear icon that leads to signature cropping by setting the display condition to `false` in `signature-card.tsx`.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 6db00455-ed99-4773-ad99-2bf36b289a0e
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/027b3d5c-14b2-4bd5-a918-b82f8808a097/6db00455-ed99-4773-ad99-2bf36b289a0e/oZkv669